### PR TITLE
Fix for screenshot updates

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -1,7 +1,7 @@
 # Haivision Connect DVR Companion Module
 This module allows for playback control of the [Haivision Connect DVR](https://www.haivision.com/products/video-services/connect-dvr/), allowing it to run headless and without a typical web browser controller.
 
-This module has been tested on versions 4.2.0 and 4.3.0 of the Connect DVR software, and has been used in multiple and various production environments since April 2019. The controls have also proven to be more reliable than stock control methods for live environments.
+This module has been tested on versions 4.2.0-4.6.1 of the Connect DVR software, and has been used in multiple and various production environments since April 2019. The controls have also proven to be more reliable than stock control methods for live environments.
 
 ![Typical setup screenshot](images/screenshot.png)
 

--- a/index.js
+++ b/index.js
@@ -9,8 +9,8 @@ const sharp = require('sharp');
 
 /**
  * Companion instance for managing Haivision DE devices
- * 
- * @version 1.0.0
+ *
+ * @version 1.0.5
  * @since 1.0.0
  * @author Justin Osborne (<osborne@churchofthehighlands.com>)
  */
@@ -882,7 +882,8 @@ class instance extends instance_skel {
 	}
 
 	get_latest_image(force = false) {
-		let cur_time = Date.now();
+        let cur_time = Date.now();
+        var image_location;
 
 		// Do not refresh if last refresh was recent
 		if(!force && this._next_preview_refresh > cur_time) {
@@ -890,8 +891,14 @@ class instance extends instance_skel {
 		}
 
 		try {
+            // Version 4.6+ includes the image in the stream
+            if('image_primary' in this.player_status) {
+                image_location = this.player_status.image_primary;
+            } else {
+                image_location = 'assets/img/live_screenshot_primary.jpg';
+            }
 			const buff = request.get({
-				url: 'https://' + this.config.host + '/assets/img/live_screenshot_primary.jpg',
+				url: 'https://' + this.config.host + '/' + image_location,
 				encoding: null
 			}, (error, resp, body) => {
 				sharp(new Buffer(body))

--- a/index.js
+++ b/index.js
@@ -882,8 +882,8 @@ class instance extends instance_skel {
 	}
 
 	get_latest_image(force = false) {
-        let cur_time = Date.now();
-        var image_location;
+		let cur_time = Date.now();
+		var image_location;
 
 		// Do not refresh if last refresh was recent
 		if(!force && this._next_preview_refresh > cur_time) {
@@ -891,12 +891,12 @@ class instance extends instance_skel {
 		}
 
 		try {
-            // Version 4.6+ includes the image in the stream
-            if('image_primary' in this.player_status) {
-                image_location = this.player_status.image_primary;
-            } else {
-                image_location = 'assets/img/live_screenshot_primary.jpg';
-            }
+			// Version 4.6+ includes the image in the stream
+			if('image_primary' in this.player_status) {
+				image_location = this.player_status.image_primary;
+			} else {
+				image_location = 'assets/img/live_screenshot_primary.jpg';
+			}
 			const buff = request.get({
 				url: 'https://' + this.config.host + '/' + image_location,
 				encoding: null

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "haivision-connectdvr",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"description": "Haivision Connect DVR for Companion.",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
Newer versions of ConnectDVR move the screenshot image location and also send the location via the socket io connection.