### PR TITLE
Fix: Node12 Buffer Update

### DIFF
--- a/index.js
+++ b/index.js
@@ -950,7 +950,7 @@ class instance extends instance_skel {
 				encoding: null
 			}, (error, resp, body) => {
 				try {
-					sharp(new Buffer(body))
+					sharp(Buffer.from(body))
 						.resize(72, 48)
 						.png()
 						.toBuffer((err, buffer) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "haivision-connectdvr",
-	"version": "1.0.8",
+	"version": "1.0.9",
 	"description": "Haivision Connect DVR for Companion.",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
Updated uses of the deprecated `new Buffer()` to the Node12 compliant functions `Buffer.from()` and `Buffer.alloc()`.

Changes made following the guidelines of Variant 1 of the NodeJS Buffer constructor deprecation guide  https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/