### PR TITLE
allows for multitrack audio output

### DIFF
--- a/index.js
+++ b/index.js
@@ -538,7 +538,7 @@ class instance extends instance_skel {
 
 		this.log('info', 'Loading channel ' + id + ' at ' + init_time + '.');
 
-		this.socket.emit('sendAndCallback2', 'playback:loadChannel', id, init_time, false, false, callback);
+		this.socket.emit('sendAndCallback2', 'playback:loadChannel', id, init_time, false, -1, callback);
 		this.set_live_channel(id);
 
 		return true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "haivision-connectdvr",
-	"version": "1.0.9",
+	"version": "1.1.0",
 	"description": "Haivision Connect DVR for Companion.",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
Note that this shouldn't negatively affect anything since previously, if there were more than a single stereo pair, it would just exclude those from the output when playing. now, it'll send all (1-16) if there are more than a single pair.

The UI for this always plays the multi-tracks without an option to turn them off in the output. It was only this module that wouldn't do that.

As a side note, there's a potential to offer outputs for different tracks as 1/2 output. The UI doesn't allow it that I can find. And since the socket doesn't return the information about what track is playing, it could potentially have issues if the UI/another companion instance was running. Hence why I'm not going to implement that at this time. Our use case also doesn't require it so I can't really do any testing with it.