### PR TITLE
Fixed live streaming bug + feedback upgrades

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -6,13 +6,21 @@ This module has been tested on versions 4.2.0-4.6.1 of the Connect DVR software,
 ![Typical setup screenshot](images/screenshot.png)
 
 ## Features
+### Controls
 - Loading/playing channels
 - Play/pause
-- Live output scrubbing (forward/backwards controls)
+- Live output scrubbing (forward/backwards controls, "skip time")
 - Setting and recalling cuepoints
-- **Feedbacks**
-	- Channel is active (changing colors)
-	- Channel is currently downloading/streaming (text and color changes)
-	- Output screen is playing/stopped
-	- Cuepoints feedback (if saved), offering a screenshot and/or color changes
-	- Preview of current output
+- Rebooting device (if using admin login)
+
+### Feedbacks
+- Channel is active
+- Channel is currently downloading/streaming
+- Output screen is playing/stopped
+- Cuepoints feedback (if saved), offering a screenshot and/or color changes
+- Preview image of current output
+
+### Variables
+- Time played
+- Duration of current clip
+- Time remaining

--- a/index.js
+++ b/index.js
@@ -71,12 +71,17 @@ class instance extends instance_skel {
 			{
 				label: 'Current duration of playing video.',
 				name:  'duration'
+			},
+			{
+				label: 'Remaining time in playing video.',
+				name:  'remaining'
 			}
 		];
 
 		this.setVariableDefinitions(variables);
 		this.setVariable('time', '00:00:00');
 		this.setVariable('duration', '00:00:00');
+		this.setVariable('remaining', '00:00:00');
 	}
 
 	/**
@@ -163,6 +168,9 @@ class instance extends instance_skel {
 		// If current channel is playing, update the duration variable
 		if(id === this.cur_channel) {
 			this.setVariable('duration', this._userFriendlyTime(this.channels[this.cur_channel].duration));
+			if('time' in this.player_status) {
+				this.setVariable('remaining', this._userFriendlyTime(this.channels[this.cur_channel].duration - this.player_status.time));
+			}
 		}
 
 		// cloud_duration is sent often for all channels, so we'll use it to validate that the duration is increasing

--- a/index.js
+++ b/index.js
@@ -19,8 +19,6 @@ class instance extends instance_skel {
 		super(system, id, config);
 
 		this.defineConst('MIN_BUFFER_TIME', 25);
-		this.defineConst('USE_STREAM_CACHE', true); // Use cloud_cache instead of isLive param
-		this.defineConst('CACHE_FEEDBACK_TIME', 30000); // Check for caching stream every 30 seconds
 		this.defineConst('RECONNECT_TIMEOUT', 10); // Number of seconds to try reconnect
 		this.defineConst('REBOOT_WAIT_TIME', 210); // Number of seconds to wait until next login after reboot; usually back up within 3.5 mins
 		this.defineConst('PREVIEW_REFRESH', 1500); // Only pull thumbnail every x millisec

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "haivision-connectdvr",
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"description": "Haivision Connect DVR for Companion.",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
- Upgraded feedbacks to use advanced
- Fixed issue with boolean feedbacks
- Fixed live/streaming bug where if there was "cloud_duration" left when the encoder was stopped, it'd keep showing as "live". Now looking for the latest "duration" update. If duration has updated recently, the channel is either downloading or "live".
- Fixed issues with image pulling incorrectly
- Time variables now start at `00:00:00` vs "Not playing"
- If video is already stopped, it'll pull the latest time on load
- Added time remaining variable