### PR TITLE
2.x patch: use v2 of socket.io-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "haivision-connectdvr",
-	"version": "1.1.8",
+	"version": "1.1.9",
 	"description": "Haivision Connect DVR for Companion.",
 	"main": "index.js",
 	"scripts": {
@@ -22,5 +22,8 @@
 		"type": "git",
 		"url": "git+https://github.com/bitfocus/companion-module-haivision-connectdvr.git"
 	},
-	"api_version": "1.0.0"
+	"api_version": "1.0.0",
+	"dependencies": {
+		"socket.io-client": "^2.0.0"
+	}
 }


### PR DESCRIPTION
needs to be merged into a new v2x-patches branch (not master)